### PR TITLE
fixes #6376 Update views_ui.admin.inc

### DIFF
--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -3865,7 +3865,7 @@ function views_ui_add_item_form($form, &$form_state) {
       'data-views-offset' => 'bottom',
     ),
   );
-  views_ui_standard_form_buttons($form, $form_state, 'views_ui_add_item_form', t('Add and configure @types', array('@types' => $ltitle)));
+  views_ui_standard_form_buttons($form, $form_state, 'views_ui_add_item_form', t('Add and configure !types', array('!types' => $ltitle)));
 
   // Remove the default submit function.
   $form['actions']['submit']['#submit'] = array_diff($form['actions']['submit']['#submit'], array('views_ui_standard_submit'));


### PR DESCRIPTION
do not sanitize views ui form buttons text

Fixes [#6376](https://github.com/backdrop/backdrop-issues/issues/6376)

I'm aware that this will not sanitize the button's text. I don't know whether this would be so necessary here. Could the translation file be used to hack the form?

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
