### PR TITLE
Fixes #6733: Move title of confirm form to a backdrop message

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3498,7 +3498,7 @@ function confirm_form($form, $question, $path, $description = NULL, $yes = NULL,
     $options = array('path' => $path);
   }
 
-  backdrop_set_title($question, PASS_THROUGH);
+  backdrop_set_message($question, 'warning');
 
   $form['#attributes']['class'][] = 'confirmation';
   $form['description'] = array('#markup' => $description);


### PR DESCRIPTION
Change backdrop_set_title() to backdrop_set_message()

Fixes [#6733](https://github.com/backdrop/backdrop-issues/issues/6733)

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
